### PR TITLE
Enforce column ordering

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/PgSQL.php
+++ b/src/Keboola/DbExtractor/Extractor/PgSQL.php
@@ -354,6 +354,8 @@ class PgSQL extends Extractor
                 $tableDefs[$curTable]['columns'][$column['ordinal_position'] - 1]['foreignKeyRef'] =
                     $column['constraint_name'];
             }
+            // make sure columns are sorted by index which is ordinal_position - 1
+            ksort($tableDefs[$curTable]['columns']);
         }
         return array_values($tableDefs);
     }


### PR DESCRIPTION
Unfortunately the test passes even without the extra enforcement, but this was checked against the originating issue #32 to confirm required result.