### PR TITLE
split gettables

### DIFF
--- a/src/Keboola/DbExtractor/Configuration/PgsqlGetTablesDefinition.php
+++ b/src/Keboola/DbExtractor/Configuration/PgsqlGetTablesDefinition.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class PgsqlGetTablesDefinition extends ActionConfigRowDefinition
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('parameters');
+
+        // @formatter:off
+        $rootNode
+            ->children()
+                ->scalarNode('data_dir')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('extractor_class')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('db')
+                    ->children()
+                        ->scalarNode('driver')->end()
+                        ->scalarNode('host')->end()
+                        ->scalarNode('port')->end()
+                        ->scalarNode('database')
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->scalarNode('user')
+                            ->isRequired()
+                        ->end()
+                        ->scalarNode('#password')
+                            ->isRequired()
+                        ->end()
+                        ->append($this->addSshNode())
+                    ->end()
+                ->end()
+                ->arrayNode('tableListFilter')
+                    ->children()
+                        ->booleanNode('listColumns')->end()
+                        ->arrayNode('tablesToList')
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('tableName')->end()
+                                    ->scalarNode('schema')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Keboola/DbExtractor/PgsqlApplication.php
+++ b/src/Keboola/DbExtractor/PgsqlApplication.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DbExtractor;
 
 use Keboola\DbExtractor\Configuration\PgsqlConfigRowDefinition;
+use Keboola\DbExtractor\Configuration\PgsqlGetTablesDefinition;
 
 class PgsqlApplication extends Application
 {
@@ -18,6 +19,8 @@ class PgsqlApplication extends Application
         if (!isset($this['parameters']['tables']) && $this['action'] === 'run') {
             // use config definition that allows --forceFallback override
             $this->setConfigDefinition(new PgsqlConfigRowDefinition());
+        } else if ($this['action'] === 'getTables') {
+            $this->setConfigDefinition(new PgsqlGetTablesDefinition());
         }
     }
 }

--- a/tests/Keboola/Extractor/ApplicationTest.php
+++ b/tests/Keboola/Extractor/ApplicationTest.php
@@ -119,22 +119,6 @@ class ApplicationTest extends BaseTest
         $this->assertFileExists($manifestFile);
     }
 
-    public function testGetTablesAction(): void
-    {
-        $config = $this->getConfig();
-        unset($config['parameters']['tables']);
-        $config['action'] = 'getTables';
-        $this->replaceConfig($config, self::CONFIG_FORMAT_JSON);
-
-        $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
-        $process->setTimeout(300);
-        $process->mustRun();
-        $this->assertJson($process->getOutput());
-
-        $this->assertEquals(0, $process->getExitCode());
-        $this->assertEquals("", $process->getErrorOutput());
-    }
-
     public function testStateFile(): void
     {
         $outputStateFile = $this->dataDir . '/out/state.json';

--- a/tests/Keboola/Extractor/GetTablesTest.php
+++ b/tests/Keboola/Extractor/GetTablesTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+use Keboola\DbExtractor\Exception\UserException;
+
+class GetTablesTest extends BaseTest
+{
+    private function replaceConfig(array $config, string $format): void
+    {
+        @unlink($this->dataDir . '/config.json');
+        @unlink($this->dataDir . '/config.yml');
+        if ($format === self::CONFIG_FORMAT_JSON) {
+            file_put_contents($this->dataDir . '/config.json', json_encode($config));
+        } else if ($format === self::CONFIG_FORMAT_YAML) {
+            file_put_contents($this->dataDir . '/config.yml', Yaml::dump($config));
+        } else {
+            throw new UserException("Invalid config format type [{$format}]");
+        }
+    }
+
+    public function testGetTables(): void
+    {
+        $config = $this->getConfig();
+
+        unset($config['parameters']['tables']);
+        $config['action'] = 'getTables';
+        $this->replaceConfig($config, self::CONFIG_FORMAT_JSON);
+
+        $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
+        $process->setTimeout(300);
+        $process->mustRun();
+        $data = json_decode($process->getOutput(), true);
+        self::assertCount(4, $data['tables']);
+        self::assertArrayHasKey('columns', $data['tables'][0]);
+        self::assertEquals(0, $process->getExitCode());
+        self::assertEquals("", $process->getErrorOutput());
+    }
+
+    public function testGetTablesNoColumns(): void
+    {
+        $config = $this->getConfig();
+
+        unset($config['parameters']['tables']);
+        $config['action'] = 'getTables';
+        $config['parameters']['tableListFilter'] = [
+            'listColumns' => false,
+        ];
+        $this->replaceConfig($config, self::CONFIG_FORMAT_JSON);
+
+        $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
+        $process->setTimeout(300);
+        $process->mustRun();
+        $data = json_decode($process->getOutput(), true);
+        self::assertCount(4, $data['tables']);
+        self::assertArrayNotHasKey('columns', $data['tables'][0]);
+        self::assertEquals(0, $process->getExitCode());
+        self::assertEquals("", $process->getErrorOutput());
+    }
+
+    public function testGetTablesOneTable(): void
+    {
+        $config = $this->getConfig();
+
+        unset($config['parameters']['tables']);
+        $config['action'] = 'getTables';
+        $config['parameters']['tableListFilter'] = [
+            'tablesToList' => [[
+                'tableName' => 'types_fk',
+                'schema' => 'public',
+            ]],
+        ];
+        $this->replaceConfig($config, self::CONFIG_FORMAT_JSON);
+
+        $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
+        $process->setTimeout(300);
+        $process->mustRun();
+        $data = json_decode($process->getOutput(), true);
+        self::assertCount(1, $data['tables']);
+        self::assertEquals('types_fk', $data['tables'][0]['name']);
+        self::assertArrayHasKey('columns', $data['tables'][0]);
+        $this->assertEquals(0, $process->getExitCode());
+        $this->assertEquals("", $process->getErrorOutput());
+    }
+
+    public function testGetTablesOneTableNoColumns(): void
+    {
+        $config = $this->getConfig();
+
+        unset($config['parameters']['tables']);
+        $config['action'] = 'getTables';
+        $config['parameters']['tableListFilter'] = [
+            'listColumns' => false,
+            'tablesToList' => [[
+                'tableName' => 'types_fk',
+                'schema' => 'public',
+            ]],
+        ];
+        $this->replaceConfig($config, self::CONFIG_FORMAT_JSON);
+
+        $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
+        $process->setTimeout(300);
+        $process->mustRun();
+        $data = json_decode($process->getOutput(), true);
+        self::assertCount(1, $data['tables']);
+        self::assertEquals('types_fk', $data['tables'][0]['name']);
+        self::assertArrayNotHasKey('columns', $data['tables'][0]);
+        $this->assertEquals(0, $process->getExitCode());
+        $this->assertEquals("", $process->getErrorOutput());
+    }
+}

--- a/tests/Keboola/Extractor/PgsqlTest.php
+++ b/tests/Keboola/Extractor/PgsqlTest.php
@@ -115,6 +115,7 @@ class PgsqlTest extends BaseTest
     {
         $config = $this->getConfig();
         $config['action'] = 'getTables';
+        unset($config['parameters']['tables']);
         $app = $this->createApplication($config);
 
         $result = $app->run();
@@ -825,6 +826,7 @@ class PgsqlTest extends BaseTest
         echo "\nTest DB built in  " . $dbBuildTime . " seconds.\n";
 
         $config = $this->getConfig();
+        unset($config['parameters']['tables']);
         $config['action'] = 'getTables';
 
         $jobStartTime = time();


### PR DESCRIPTION
Jsem se vcera v noci namichl a spichnul oddeleni fetchu tabulek od sloupcu, melo by to byt udelany zpetne kompatibilne, aby to slo v klidu nasadit. Jsem si plne vedom toho, ze to tam je nahastroseny a rad bych se predem vyhnul diskuzim na tema, jestli by se nemela tahle cast kodu presunout nekam jinam. 

Cilem tohole PR je co nejrychleji otestovat jestli ma vubec **smysl** nad timhle resenim uvazovat. Cili by bylo dobry to nasadit, pres API otestovat na HC (jako nejstrasnejsim pripadu), pokud to bude fungovat, tak dat do UI (mozna i pres ficuru), pokud to bude fungovat, tak dal meditovat nad tim co s tim.

Zasadni otazka je teda jestli kam to ulozit v configu - `tableListFilter` - protoze tohle se pozdeji bude menit blbe.
