### PR TITLE
Remove format parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - sshproxy
 
   pgsql:
-    image: postgres
+    image: postgres:11.5
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=some password

--- a/tests/Keboola/Extractor/ApplicationTest.php
+++ b/tests/Keboola/Extractor/ApplicationTest.php
@@ -47,7 +47,7 @@ class ApplicationTest extends BaseTest
             'remotePort' => '1433',
             'localPort' => '1234',
         ];
-        $this->replaceConfig($config, ExtractorTest::CONFIG_FORMAT_JSON);
+        $this->replaceConfig($config);
 
         $process = Process::fromShellCommandline('php ' . $this->rootPath . '/run.php --data=' . $this->dataDir);
         $process->mustRun();


### PR DESCRIPTION
Fixes - https://travis-ci.org/keboola/db-extractor-pgsql/builds/595045810?utm_source=github_status&utm_medium=notification

Use postgres version 11.5 - fixes:
SQLSTATE[42703]: Undefined column: 7 ERROR:  column d.adsrc does not exist LINE 10:       d.adsrc AS default_value