### PR TITLE
Fix removed obsolete pg_attrdef.adsrc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - sshproxy
 
   pgsql:
-    image: postgres:11.5
+    image: postgres:latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=some password

--- a/src/Keboola/DbExtractor/Extractor/PgSQL.php
+++ b/src/Keboola/DbExtractor/Extractor/PgSQL.php
@@ -437,7 +437,7 @@ EOT;
       NOT a.attnotnull AS nullable,
       i.indisprimary AS primary_key,
       a.attnum AS ordinal_position,
-      d.adsrc AS default_value
+      pg_get_expr(d.adbin::pg_node_tree, d.adrelid) AS default_value
     FROM pg_attribute a
     JOIN pg_class c ON a.attrelid = c.oid AND c.reltype != 0 --indexes have 0 reltype, we don't want them here
     INNER JOIN pg_namespace ns ON ns.oid = c.relnamespace --schemas


### PR DESCRIPTION
Fix PostgreSQL12 compatibility issue.

Reason: https://www.postgresql.org/docs/12/release-12.html (removed)
Solution: https://www.postgresql.org/docs/11/catalog-pg-attrdef.html (obsolete warning)

```
The adsrc field is historical, and is best not used, because it does not track outside changes that might affect the representation of the default value. Reverse-compiling the adbin field (with pg_get_expr for example) is a better way to display the default value.
```