### PR TITLE
Allow null value in config for: incrementalFetchingLimit and column

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-PDO": "*",
         "keboola/csv": "^2.1",
         "keboola/db-extractor-common": "~13.2.4",
-        "keboola/db-extractor-config": "^1.4.5",
+        "keboola/db-extractor-config": "^1.4.6",
         "keboola/db-extractor-table-format": "^3.1.1",
         "keboola/php-component": "^8.1.2",
         "keboola/php-datatypes": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d6fda3d55e9b76102e6ba528ba984f0",
+    "content-hash": "27ad22fc22d2f2c75563c8b12b38a621",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -220,16 +220,16 @@
         },
         {
             "name": "keboola/db-extractor-config",
-            "version": "1.4.5",
+            "version": "1.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-config.git",
-                "reference": "0129ea42dac9e732f54ddb322dc35278bb5b9030"
+                "reference": "8de00d516ab91992f8cfe5fb305a800b3fc28b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-config/zipball/0129ea42dac9e732f54ddb322dc35278bb5b9030",
-                "reference": "0129ea42dac9e732f54ddb322dc35278bb5b9030",
+                "url": "https://api.github.com/repos/keboola/db-extractor-config/zipball/8de00d516ab91992f8cfe5fb305a800b3fc28b3c",
+                "reference": "8de00d516ab91992f8cfe5fb305a800b3fc28b3c",
                 "shasum": ""
             },
             "require": {
@@ -255,7 +255,7 @@
                 "MIT"
             ],
             "description": "Config definition for database extractor",
-            "time": "2020-06-19T15:04:34+00:00"
+            "time": "2020-06-26T06:33:17+00:00"
         },
         {
             "name": "keboola/db-extractor-ssh-tunnel",

--- a/tests/phpunit/IncrementalFetchingTest.php
+++ b/tests/phpunit/IncrementalFetchingTest.php
@@ -544,4 +544,43 @@ class IncrementalFetchingTest extends BaseTest
             ],
         ];
     }
+
+    public function testIncrementalFetchingColumnNull(): void
+    {
+        $this->createAutoIncrementAndTimestampTable();
+        $config = $this->getIncrementalFetchingConfig();
+        $config['parameters']['incrementalFetchingColumn'] = null;
+
+        $app = $this->createApplication($config);
+        $result = $app->run();
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertEquals(
+            [
+                'outputTable' => 'in.c-main.auto-increment-timestamp',
+                'rows' => 2,
+            ],
+            $result['imported']
+        );
+    }
+
+    public function testIncrementalFetchingColumnLimit(): void
+    {
+        $this->createAutoIncrementAndTimestampTable();
+        $config = $this->getIncrementalFetchingConfig();
+        $config['parameters']['incrementalFetchingColumn'] = 'timestamp';
+        $config['parameters']['incrementalFetchingLimit'] = null;
+
+        $app = $this->createApplication($config);
+        $result = $app->run();
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertEquals(
+            [
+                'outputTable' => 'in.c-main.auto-increment-timestamp',
+                'rows' => 2,
+            ],
+            $result['imported']
+        );
+    }
 }

--- a/tests/phpunit/IncrementalFetchingTest.php
+++ b/tests/phpunit/IncrementalFetchingTest.php
@@ -547,6 +547,7 @@ class IncrementalFetchingTest extends BaseTest
 
     public function testIncrementalFetchingColumnNull(): void
     {
+        // In old configs can be "incrementalFetchingColumn: null"
         $this->createAutoIncrementAndTimestampTable();
         $config = $this->getIncrementalFetchingConfig();
         $config['parameters']['incrementalFetchingColumn'] = null;
@@ -564,8 +565,9 @@ class IncrementalFetchingTest extends BaseTest
         );
     }
 
-    public function testIncrementalFetchingColumnLimit(): void
+    public function testIncrementalFetchingColumnLimitNull(): void
     {
+        // In old configs can be "incrementalFetchingLimit: null"
         $this->createAutoIncrementAndTimestampTable();
         $config = $this->getIncrementalFetchingConfig();
         $config['parameters']['incrementalFetchingColumn'] = 'timestamp';


### PR DESCRIPTION
Changes:
- Allowed `null` value in config for: incremental fetching `limit` / `column`.
- See: https://github.com/keboola/db-extractor-config/pull/21