### PR TITLE
Recreate CSV writer on error

### DIFF
--- a/src/Extractor/PgSQL.php
+++ b/src/Extractor/PgSQL.php
@@ -91,7 +91,7 @@ class PgSQL extends BaseExtractor
                 $result = $this->pdoAdapter->export(
                     $query,
                     $exportConfig,
-                    $this->createOutputCsv($exportConfig->getOutputTable())
+                    $this->getOutputFilename($exportConfig->getOutputTable())
                 );
             } catch (PDOException $pdoError) {
                 throw new UserException(


### PR DESCRIPTION
Changes:
- Recreate `CsvWriter` before retry, because some lines cloud be written in previous attempt.