### PR TITLE
Fix BC in config, allow incremental fetching limit without column

### DIFF
--- a/src/Configuration/PgsqlTableNodeDecorator.php
+++ b/src/Configuration/PgsqlTableNodeDecorator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Configuration;
+
+use Keboola\DbExtractorConfig\Configuration\NodeDefinition\TableNodesDecorator;
+
+class PgsqlTableNodeDecorator extends TableNodesDecorator
+{
+    public function normalize(array $v): array
+    {
+        // Fix BC: some old configs can contain limit but not column
+        if (!empty($v['incrementalFetchingLimit']) && empty($v['incrementalFetchingColumn'])) {
+            unset($v['incrementalFetchingLimit']);
+        }
+
+        return parent::normalize($v);
+    }
+}

--- a/src/PgsqlApplication.php
+++ b/src/PgsqlApplication.php
@@ -6,10 +6,12 @@ namespace Keboola\DbExtractor;
 
 use Keboola\DbExtractor\Configuration\PgsqlExportConfig;
 use Keboola\DbExtractor\Configuration\PgsqlConfigRowDefinition;
+use Keboola\DbExtractor\Configuration\PgsqlTableNodeDecorator;
 use Keboola\DbExtractorConfig\Config;
 use Keboola\DbExtractorConfig\Configuration\ActionConfigRowDefinition;
 use Keboola\DbExtractorConfig\Configuration\ConfigDefinition;
 use Keboola\DbExtractorConfig\Configuration\GetTablesListFilterDefinition;
+use Keboola\DbExtractorConfig\Configuration\NodeDefinition\TableNodesDecorator;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
 use Psr\Log\LoggerInterface;
 
@@ -29,12 +31,18 @@ class PgsqlApplication extends Application
             $this->config = new Config($config, new GetTablesListFilterDefinition());
         } elseif ($this->isRowConfiguration($config)) {
             if ($this['action'] === 'run') {
-                $this->config = new Config($config, new PgsqlConfigRowDefinition());
+                $this->config = new Config(
+                    $config,
+                    new PgsqlConfigRowDefinition(null, null, null, new PgsqlTableNodeDecorator())
+                );
             } else {
                 $this->config = new Config($config, new ActionConfigRowDefinition());
             }
         } else {
-            $this->config = new Config($config, new ConfigDefinition());
+            $this->config = new Config(
+                $config,
+                new ConfigDefinition(null, null, null, new PgsqlTableNodeDecorator())
+            );
         }
     }
 

--- a/tests/phpunit/IncrementalFetchingTest.php
+++ b/tests/phpunit/IncrementalFetchingTest.php
@@ -585,4 +585,25 @@ class IncrementalFetchingTest extends BaseTest
             $result['imported']
         );
     }
+
+    public function testIncrementalFetchingLimitPresentColumnMissing(): void
+    {
+        // In old configs can be "incrementalFetchingLimit" set, but "incrementalFetchingColumn" missing
+        $this->createAutoIncrementAndTimestampTable();
+        $config = $this->getIncrementalFetchingConfig();
+        unset($config['parameters']['incrementalFetchingColumn']);
+        $config['parameters']['incrementalFetchingLimit'] = 50000;
+
+        $app = $this->createApplication($config);
+        $result = $app->run();
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertEquals(
+            [
+                'outputTable' => 'in.c-main.auto-increment-timestamp',
+                'rows' => 2,
+            ],
+            $result['imported']
+        );
+    }
 }


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1593694129063200

Changes:
- If `incrementalFetchingLimit` is present in configuration, but `incrementalFetchingColumn` not, then is this problem ignored (incremental fetching is not used).