### PR TITLE
table type is not required property

### DIFF
--- a/src/Extractor/PgSQLMetadataProvider.php
+++ b/src/Extractor/PgSQLMetadataProvider.php
@@ -53,7 +53,7 @@ class PgSQLMetadataProvider implements MetadataProvider
         $columnBuilders = [];
 
         // Process tables
-        $tableRequiredProperties = ['schema', 'type'];
+        $tableRequiredProperties = ['schema'];
         $columnRequiredProperties= ['ordinalPosition', 'nullable'];
         $builder = MetadataBuilder::create($tableRequiredProperties, $columnRequiredProperties);
         foreach ($this->queryTablesAndColumns($whitelist, $loadColumns) as $data) {


### PR DESCRIPTION
Když se nenastaví typ tabulky tak extractor neprojde kontrolou povinných položek - tak se nesmí kontrolovat `type` jako povinná položka tabulky

https://keboola.slack.com/archives/C09U3R1J4/p1594807891026800