### PR TITLE
feat(ST-3887): add TCP keepalive parameters to libpq DSN

### DIFF
--- a/src/Extractor/PgSQLDsnFactory.php
+++ b/src/Extractor/PgSQLDsnFactory.php
@@ -47,6 +47,13 @@ class PgSQLDsnFactory
         $dsn['user'] = $dbConfig->getUsername();
         $dsn['dbname'] = $dbConfig->getDatabase();
 
+        // TCP keepalive parameters to prevent connection drops by NAT/firewall devices
+        // These call setsockopt() directly on the socket via libpq, bypassing kernel defaults
+        $dsn['keepalives'] = '1';
+        $dsn['keepalives_idle'] = '60';
+        $dsn['keepalives_interval'] = '10';
+        $dsn['keepalives_count'] = '5';
+
         if ($dbConfig->hasSSLConnection()) {
             $tempDir = new Temp('ssl');
             $sslConnection = $dbConfig->getSslConnectionConfig();

--- a/tests/functional/bool-consistency/expected-stdout
+++ b/tests/functional/bool-consistency/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "types" to "in.c-main.bool_consistency_test".
 Exporting by "Copy" adapter.
 Adapter "Copy" skipped: Disabled in configuration.

--- a/tests/functional/custom-query-newline/expected-stdout
+++ b/tests/functional/custom-query-newline/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/empty-table-query/expected-stdout
+++ b/tests/functional/empty-table-query/expected-stdout
@@ -1,3 +1,3 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "escaping" to "in.c-main.escaping".
 Exporting by "Copy" adapter.

--- a/tests/functional/empty-table/expected-stdout
+++ b/tests/functional/empty-table/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "escaping" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Found database server version: %d.

--- a/tests/functional/error-incremental-fetching-fake-column/expected-stdout
+++ b/tests/functional/error-incremental-fetching-fake-column/expected-stdout
@@ -1,2 +1,2 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Found database server version: %d.

--- a/tests/functional/error-incremental-fetching-string-column/expected-stdout
+++ b/tests/functional/error-incremental-fetching-string-column/expected-stdout
@@ -1,2 +1,2 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Found database server version: %d.

--- a/tests/functional/incremental-fetching-empty-rows/expected-stdout
+++ b/tests/functional/incremental-fetching-empty-rows/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Found database server version: %d.
 Exporting "auto-increment-timestamp" to "in.c-main.auto-increment-timestamp".
 Exporting by "Copy" adapter.

--- a/tests/functional/run-action-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-native-types-manifest/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/run-action-row-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-debug-logging/expected-stdout
@@ -1,5 +1,5 @@
 [%s] DEBUG: Component initialization completed [] []
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 [%s] DEBUG: Running query: "SELECT has_schema_privilege(current_schema(), 'CREATE');". [] []

--- a/tests/functional/run-action-row-force-pdo/expected-stdout
+++ b/tests/functional/run-action-row-force-pdo/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Adapter "Copy" skipped: Disabled in configuration.

--- a/tests/functional/run-action-row-pdo-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-pdo-debug-logging/expected-stdout
@@ -1,5 +1,5 @@
 [%s] DEBUG: Component initialization completed [] []
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Adapter "Copy" skipped: Disabled in configuration.

--- a/tests/functional/run-action-row-via-ssh-tunnel/expected-stdout
+++ b/tests/functional/run-action-row-via-ssh-tunnel/expected-stdout
@@ -1,5 +1,5 @@
 Creating SSH tunnel to 'sshproxy' on local port '1234'
-Creating PDO connection to "pgsql:host=127.0.0.1;port=1234;dbname=postgres;".
+Creating PDO connection to "pgsql:host=127.0.0.1;port=1234;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/run-action-row/expected-stdout
+++ b/tests/functional/run-action-row/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/run-action-with-read-only-user/expected-stdout
+++ b/tests/functional/run-action-with-read-only-user/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/run-action/expected-stdout
+++ b/tests/functional/run-action/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/set-pdo-batch-size/expected-stdout
+++ b/tests/functional/set-pdo-batch-size/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
 Adapter "Copy" skipped: Disabled in configuration.

--- a/tests/functional/set-timezone-via-copy-adapter-with-user-init-queries/expected-stdout
+++ b/tests/functional/set-timezone-via-copy-adapter-with-user-init-queries/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "timezone" to "in.c-main.timezone".
 Exporting by "Copy" adapter.
 Exported "1" rows to "in.c-main.timezone".

--- a/tests/functional/table-columns-query/expected-stdout
+++ b/tests/functional/table-columns-query/expected-stdout
@@ -1,4 +1,4 @@
-Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
+Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;keepalives=1;keepalives_idle=60;keepalives_interval=10;keepalives_count=5;".
 Exporting "types" to "in.c-main.types".
 Exporting by "Copy" adapter.
 Found database server version: %d.


### PR DESCRIPTION
## Summary

Adds explicit TCP keepalive parameters to `PgSQLDsnFactory::create()` to prevent connection drops caused by NAT/firewall devices dropping idle TCP connections.

**Context**: [ST-3887](https://linear.app/keboola/issue/ST-3887) — PostgreSQL extractor on the CS stack experiences intermittent "server closed the connection unexpectedly" errors. The OS-level fix (`container-tcpkeepalive-60s-override` via [infrastructure-plugin-update-components#762](https://github.com/keboola/infrastructure-plugin-update-components/pull/762)) was deployed but did not resolve the issue.

**Root cause**: The `--sysctl net.ipv4.tcp_keepalive_time=60` sets the kernel default for `TCP_KEEPIDLE`, but libpq only uses this kernel default when `keepalives_idle` is not explicitly set in the DSN. If the sysctl doesn't properly propagate to the container's network namespace, the kernel default remains 7200s (2 hours). By setting `keepalives_idle=60` explicitly in the DSN, libpq calls `setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, 60)` directly on the socket, **bypassing any kernel settings**.

**Parameters added to all connections (both PDO and psql CLI)**:
- `keepalives=1` — explicitly enable TCP keepalive (already default, but explicit)
- `keepalives_idle=60` — send first keepalive after 60s of inactivity
- `keepalives_interval=10` — retry every 10s if no response
- `keepalives_count=5` — give up after 5 failed keepalives

These are [standard libpq connection parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-KEEPALIVES) supported by both PHP PDO pgsql and the psql CLI tool.

**Change scope**: Only `PgSQLDsnFactory::create()` is modified — the base method used by both `createForPdo()` and `createForCli()`, so both connection paths benefit automatically. Functional test expected outputs updated accordingly.

## Review & Testing Checklist for Human
- [ ] Verify the keepalive parameters appear correctly in the PDO DSN string (semicolon-separated: `keepalives=1;keepalives_idle=60;...`)
- [ ] Verify the keepalive parameters appear correctly in the psql CLI connection string (space-separated: `keepalives=1 keepalives_idle=60 ...`)
- [ ] Deploy to CS stack and monitor Datadog for reduction in "server closed the connection unexpectedly" errors over 24-48h
- [ ] Confirm no regression on other stacks (these parameters are safe defaults for all PostgreSQL connections)

### Notes
- This is a defense-in-depth fix that works alongside the OS-level `container-tcpkeepalive-60s-override` feature
- The same two-layer approach (OS + application level) was used successfully for the Oracle extractor ([java-oracle-exporter#56](https://github.com/keboola/java-oracle-exporter/pull/56))
- These keepalive values are universally safe — they only affect idle connections and have no impact on active data transfer

## Release Notes
**Justification, description**

Adds TCP keepalive parameters to PostgreSQL connection strings to prevent connection drops caused by NAT/firewall devices on the network path. This fixes intermittent "server closed the connection unexpectedly" errors observed on stacks with strict network idle timeouts.

**Plans for Customer Communication**

N/A — transparent fix, no configuration changes required from customers.

**Impact Analysis**

Low risk. Adds standard libpq keepalive parameters to all PostgreSQL connections. These parameters only affect idle connections (sending small keepalive packets every 60s) and have no impact on active data transfer or query execution. The `keepalives=1` setting is already the libpq default.

**Deployment Plan**

Standard component release. After merge, the new image will be deployed to all stacks. The CS stack should be monitored for error reduction.

**Rollback Plan**

Revert this commit and release. The keepalive parameters are additive and their removal returns to previous behavior.

**Post-Release Support Plan**

Monitor Datadog APM traces for `keboola.ex-db-pgsql` on `cloud-keboola-cs` — error rate should drop from ~10-12% to near zero within 24-48h of deployment.

Link to Devin session: https://app.devin.ai/sessions/3a1b2b61195d4f32ba3f73534a7b542e
Requested by: @kacurez