### PR TITLE
feat: export via COPY TO STDOUT instead of temporary view (SUPPORT-17025)

### DIFF
--- a/src/Extractor/CopyAdapter.php
+++ b/src/Extractor/CopyAdapter.php
@@ -98,22 +98,17 @@ class CopyAdapter implements ExportAdapter
         $sql = '\encoding UTF8' . PHP_EOL .
             implode(PHP_EOL, $this->databaseConfig->getInitQueries()) . PHP_EOL;
 
-        if ($this->canUserCreateView() && !$this->isTransactionReadOnly()) {
-            $viewName = uniqid();
-            $sql .= 'CREATE TEMP VIEW "' . $viewName . '" AS ' . $trimmedQuery . ';' . PHP_EOL .
-                sprintf(
-                    "\COPY (%s) TO '%s' WITH CSV DELIMITER ',' FORCE QUOTE *;",
-                    'SELECT * FROM "' . $viewName . '"',
-                    $csvPath,
-                ) . PHP_EOL .
-                'DROP VIEW "' . $viewName . '";';
-        } else {
-            $sql .= sprintf(
-                "\COPY (%s) TO '%s' WITH CSV DELIMITER ',' FORCE QUOTE *;",
+        // Export data using a server-side "COPY ... TO STDOUT" statement redirected to the output
+        // file with the psql "\o" meta-command. Unlike the client-side "\copy" meta-command,
+        // "COPY ... TO STDOUT" is a regular SQL statement, so it supports multi-line queries without
+        // wrapping them in a temporary view. This avoids any DDL (CREATE/DROP TEMP VIEW) on the
+        // source database during export.
+        $sql .= sprintf("\o '%s'", $csvPath) . PHP_EOL .
+            sprintf(
+                "COPY (%s) TO STDOUT WITH CSV DELIMITER ',' FORCE QUOTE *;",
                 $trimmedQuery,
-                $csvPath,
-            );
-        }
+            ) . PHP_EOL .
+            '\o';
 
         try {
             $this->runPsqlProcess($sql, null);
@@ -202,29 +197,5 @@ class CopyAdapter implements ExportAdapter
         }
 
         return $lastExportedRow[$columnIndex];
-    }
-
-    protected function canUserCreateView(): bool
-    {
-        try {
-            return $this->runPsqlProcess(
-                'SELECT has_schema_privilege(current_schema(), \'CREATE\');',
-                null,
-            ) === 't';
-        } catch (CopyAdapterException $e) {
-            throw new CopyAdapterQueryException($e->getMessage(), 0, $e);
-        }
-    }
-
-    protected function isTransactionReadOnly(): bool
-    {
-        try {
-            return $this->runPsqlProcess(
-                'SHOW transaction_read_only;',
-                null,
-            ) === 'on';
-        } catch (CopyAdapterException $e) {
-            throw new CopyAdapterQueryException($e->getMessage(), 0, $e);
-        }
     }
 }

--- a/tests/functional/error-invalid-query/expected-stderr
+++ b/tests/functional/error-invalid-query/expected-stderr
@@ -1,3 +1,3 @@
-Export by "Copy" adapter failed: ERROR:  column "something" does not exist LINE 1: CREATE TEMP VIEW "%x" AS SELECT something, fake;%A
+Export by "Copy" adapter failed: ERROR:  column "something" does not exist LINE 1: COPY (SELECT something, fake) TO STDOUT WITH CSV DELIMITER '...%A
 Export by "PDO" adapter failed: [in.c-main.escaping]: DB query failed: SQLSTATE[42703]: Undefined column: 7 ERROR:  column "something" does not exist%A Tried 5 times.
 [in.c-main.escaping]: DB query failed: SQLSTATE[42703]: Undefined column: 7 ERROR:  column "something" does not exist %A Tried 5 times.

--- a/tests/functional/run-action-row-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-debug-logging/expected-stdout
@@ -2,7 +2,5 @@
 Creating PDO connection to "pgsql:host=%s;port=5432;dbname=postgres;".
 Exporting "sales" to "in.c-main.escaping".
 Exporting by "Copy" adapter.
-[%s] DEBUG: Running query: "SELECT has_schema_privilege(current_schema(), 'CREATE');". [] []
-[%s] DEBUG: Running query: "SHOW transaction_read_only;". [] []
-[%s] DEBUG: Running query: "\encoding UTF8  CREATE TEMP VIEW "%s" AS SELECT * FROM escaping; \COPY (SELECT * FROM "%s") TO '/tmp/run-%s.%s/out/tables/in.c-main.escaping.csv' WITH CSV DELIMITER ',' FORCE QUOTE *; DROP VIEW "%s";". [] []
+[%s] DEBUG: Running query: "\encoding UTF8  \o '/tmp/run-%s.%s/out/tables/in.c-main.escaping.csv' COPY (SELECT * FROM escaping) TO STDOUT WITH CSV DELIMITER ',' FORCE QUOTE *; \o". [] []
 Exported "7" rows to "in.c-main.escaping".


### PR DESCRIPTION
## Summary
The `Copy` export adapter no longer creates a temporary view on the source database. Previously, when the DB user could create a view, each export ran DDL against the source:

```sql
CREATE TEMP VIEW "<uid>" AS <query>;
\COPY (SELECT * FROM "<uid>") TO '<file>' WITH CSV ...;
DROP VIEW "<uid>";
```

The temp view existed only to work around a psql limitation: the client-side `\copy` meta-command must fit on a **single line**, so multi-line queries fail unless wrapped in a view.

This PR switches to the server-side `COPY (...) TO STDOUT` SQL statement, redirecting its output to the target file with psql's `\o` meta-command:

```
\encoding UTF8
<initQueries>
\o '<file>'
COPY (<query>) TO STDOUT WITH CSV DELIMITER ',' FORCE QUOTE *;
\o
```

`COPY ... TO STDOUT` is a regular SQL statement, so it handles multi-line queries **without any DDL** and requires no special privileges (any user that can `SELECT` can run it). Output CSV is byte-for-byte the same as before.

Because no view is created anymore, the pre-flight `canUserCreateView()` (`has_schema_privilege(...)`) and `isTransactionReadOnly()` (`SHOW transaction_read_only`) probe queries — and the whole view/non-view branch — are removed. This also drops two round-trip queries per export.

This directly addresses the customer request in SUPPORT-17025 (replication with no DDL updates on the source).

### Testing
- `composer ci` passes (phpcs, phpstan, unit + functional).
- Updated expected output for `run-action-row-debug-logging` (logged SQL) and `error-invalid-query` (error now references `COPY (...) TO STDOUT` instead of `CREATE TEMP VIEW`).
- `run-action-with-read-only-user` still passes, confirming read-only users export correctly via the new path.

## Release Notes
**Justification, description**

Customer (SUPPORT-17025) requires DB replication with no DDL changes on the source. The Postgres extractor's `Copy` adapter created/dropped a temporary view per export; it now uses `COPY (...) TO STDOUT` redirected to the output file, avoiding all DDL while producing identical output.

**Plans for Customer Communication**

Provide the customer with a testing image tag to validate against their source before release.

**Impact Analysis**

Applies to all Postgres extractor exports using the `Copy` (psql) adapter. Output CSV is unchanged. Multi-line queries continue to work (previously handled via the temp view). Read-only users and users without CREATE privilege are unaffected (already used a direct COPY path).

**Deployment Plan**

Standard component release after review + CI.

**Rollback Plan**

Revert this PR / redeploy the previous image tag.

**Post-Release Support Plan**

Monitor extractor job error rates in Datadog for the `Copy` adapter.


Link to Devin session: https://app.devin.ai/sessions/66131de271cc4c3f98cda8411b9c4602
Requested by: @terezaskalova